### PR TITLE
Modify split words (` : `-> `::`) to reduce stub plan miscode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # bats-mock
+
 Mocking/stubbing library for BATS (Bash Automated Testing System)
 
 ## bats-core
@@ -10,14 +11,14 @@ There are great things happening in the `bats` ecosystem! Anyone actively using 
 Recommended installation is via git submodule. Assuming your project's bats
 tests are in `test`:
 
-``` sh
+```sh
 git submodule add https://github.com/jasonkarns/bats-mock test/helpers/mocks
 git commit -am 'added bats-mock module'
 ```
 
 then in `test/test_helper.bash`:
 
-``` bash
+```bash
 load helpers/mocks/stub
 ```
 
@@ -25,13 +26,13 @@ load helpers/mocks/stub
 
 Also available as an [npm module](https://www.npmjs.com/package/bats-mock) if you're into that sort of thing.
 
-``` sh
+```sh
 npm install --save-dev bats-mock
 ```
 
 then in `test/test_helper.bash`:
 
-``` bash
+```bash
 load ../node_modules/bats-mock/stub
 ```
 
@@ -47,9 +48,9 @@ After loading `bats-mock/stub` you have two new functions defined:
 
 The `stub` function takes a program name as its first argument, and any remaining arguments goes into the stub plan, one line per arg.
 
-Each plan line represents an expected invocation, with a list of expected arguments followed by a command to execute in case the arguments matched, separated with a colon:
+Each plan line represents an expected invocation, with a list of expected arguments followed by a command to execute in case the arguments matched, separated with a `::`:
 
-    arg1 arg2 ... : only_run if args matched
+    arg1 arg2 ...::only_run if args matched
 
 The expected args (and the colon) is optional.
 
@@ -67,8 +68,8 @@ format_date() {
 setup() {
   _DATE_ARGS='-r 222'
   stub date \
-      "${_DATE_ARGS} : echo 'I am stubbed!'" \
-      "${_DATE_ARGS} : echo 'Wed Dec 31 18:03:42 CST 1969'"
+      "${_DATE_ARGS}::echo 'I am stubbed!'" \
+      "${_DATE_ARGS}::echo 'Wed Dec 31 18:03:42 CST 1969'"
 }
 
 teardown() {

--- a/binstub
+++ b/binstub
@@ -39,9 +39,11 @@ while IFS= read -r line; do
     # Split the line into an array of arguments to
     # match and a command to run to produce output.
     command=" $line"
-    if [ "$command" != "${command/ : }" ]; then
-      patterns="${command%% : *}"
-      command="${command#* : }"
+
+    # Split word is `::`
+    if [ "$command" != "${command/::}" ]; then
+      patterns="${command%%::*}"
+      command="${command##*::}"
     fi
 
     # Naively split patterns by whitespace for now.

--- a/test/date.bats
+++ b/test/date.bats
@@ -11,8 +11,8 @@ format_date() {
 setup() {
   _DATE_ARGS='-r 222'
   stub date \
-      "${_DATE_ARGS} : echo 'I am stubbed!'" \
-      "${_DATE_ARGS} : echo 'Wed Dec 31 18:03:42 CST 1969'"
+      "${_DATE_ARGS}::echo 'I am stubbed!'" \
+      "${_DATE_ARGS}::echo 'Wed Dec 31 18:03:42 CST 1969'"
 }
 
 teardown() {


### PR DESCRIPTION
The `:` operator requires white space on both sides. So, the following code is to be error.

```bash
_DATE_ARGS='-r 222'
# The `:` operator requires white space on both sides.
 stub date "${_DATE_ARGS} :echo 'I am stubbed!'"
```

executed result: 

```bash
✗ date format util formats date with expected arguments
   (in test file test/date.bats, line 24)
     `[ "$result" == 'I am stubbed!' ]' failed

1 test, 1 failure
```

From this, I  modify split words (` : `-> `::`) to reduce stub plan miscode.